### PR TITLE
Add support for reading .strtab and .dynsym/.symtab

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2016 Frédéric Bour
+Copyright (c) 2016 Jane Street Group, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE.interval-tree
+++ b/LICENSE.interval-tree
@@ -1,0 +1,27 @@
+Copyright (c) 2014, Structural Bioinformatics Team
+Division of Structural and Synthetic Biology
+CLST, RIKEN
+1-7-22 Suehiro-cho, Tsurumi-ku, Yokohama, Kanagawa 230-0045, Japan
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-all: decodedline
+all: decodedline functions
 
 owee:
 	make -C .. owee
@@ -6,5 +6,8 @@ owee:
 decodedline: decodedline.ml owee
 	ocamlopt -o $@ -g unix.cmxa bigarray.cmxa -I ../src ../src/owee.cmxa decodedline.ml
 
+functions: functions.ml owee
+	ocamlopt -o $@ -g unix.cmxa bigarray.cmxa -I ../src ../src/owee.cmxa functions.ml
+
 clean:
-	rm -f *.cm* *.o *.a decodedline
+	rm -f *.cm* *.o *.a decodedline functions

--- a/examples/functions.ml
+++ b/examples/functions.ml
@@ -1,0 +1,49 @@
+[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+
+let path, address =
+  let argv_len = Array.length Sys.argv in
+  if argv_len < 1 || argv_len > 3 then
+    (prerr_endline ("Usage: " ^ Sys.argv.(0)
+      ^ " my_binary.elf [ADDRESS]"); exit 1)
+  else
+    let path = Sys.argv.(1) in
+    let address =
+      if argv_len = 3 then Some (Int64.of_string Sys.argv.(2)) else None
+    in
+    path, address
+
+let buffer =
+  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+  let len = Unix.lseek fd 0 Unix.SEEK_END in
+  let map = Bigarray.Array1.map_file fd
+      Bigarray.int8_unsigned Bigarray.c_layout false len in
+  Unix.close fd;
+  map
+
+let _header, sections = Owee_elf.read_elf buffer
+
+let () =
+  match Owee_elf.find_symbol_table buffer sections with
+  | None -> failwith "Symbol table not found"
+  | Some symtab ->
+    match Owee_elf.find_string_table buffer sections with
+    | None -> failwith "String table not found"
+    | Some strtab ->
+      let module S = Owee_elf.Symbol_table.Symbol in
+      let symbol_name sym =
+        match S.name sym strtab with
+        | None -> "<none>"
+        | Some name -> name
+      in
+      match address with
+      | None ->
+        Printf.printf "All symbols:\n";
+        Owee_elf.Symbol_table.iter symtab ~f:(fun sym ->
+          Printf.printf "%s" (symbol_name sym);
+          match S.type_attribute sym with
+          | Func -> Printf.printf " (function)\n";
+          | _ -> Printf.printf "\n")
+      | Some address ->
+        Printf.printf "Symbols overlapping address 0x%Lx:\n" address;
+        List.iter (fun sym -> Printf.printf "%s\n" (symbol_name sym))
+          (Owee_elf.Symbol_table.functions_enclosing_address symtab ~address)

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,8 @@ endif
 
 RESULT = owee
 
-SOURCES = owee_buf.mli owee_buf.ml owee_elf.mli owee_elf.ml owee_debug_line.ml \
+SOURCES = owee_buf.mli owee_buf.ml owee_interval_tree.ml owee_interval_tree.mli \
+  owee_elf.mli owee_elf.ml owee_debug_line.ml \
   owee_debug_line.mli owee_location.mli owee_location.ml owee_marker.mli \
   owee_marker.ml owee_stubs.c
 

--- a/src/owee_buf.mli
+++ b/src/owee_buf.mli
@@ -4,6 +4,7 @@ type t =
   (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
 (** Size of the buffer *)
+(* CR mshinwell: rename to "size" *)
 val dim     : t -> int
 
 (** Minimal support for error reporting. FIXME: Improve that someday. *)
@@ -20,6 +21,7 @@ type u8   = int
 type u16  = int
 type s32  = int
 type u32  = int
+(* CR mshinwell: u64 should be Int64.t *)
 type u64  = int (* Bye bye 32 bits. 63 bits ought to be enough for anyone. *)
 type s128 = int (* Ahem, we don't expect 128 bits to really consume 128 bits *)
 type u128 = int
@@ -56,5 +58,6 @@ module Read : sig
 
   (** [zero_string msg t ?maxlen ()] reads a zero-terminated string from [t],
       stopping at the first zero or when [maxlen] is reached, if it was provided. *)
+  (* CR mshinwell: delete the first argument and return an option *)
   val zero_string : string -> cursor -> ?maxlen:int -> unit -> string
 end

--- a/src/owee_elf.ml
+++ b/src/owee_elf.ml
@@ -178,8 +178,8 @@ module Symbol_table = struct
       st_info : u8;
       st_other : u8;
       st_shndx : u16;
-      st_value : u64;
-      st_size : u64;
+      st_value : Int64.t;
+      st_size : Int64.t;
     }
 
     let struct_size = (32 + 8 + 8 + 16 + 64 + 64) / 8
@@ -211,8 +211,8 @@ module Symbol_table = struct
     let name t string_table =
       String_table.get_string string_table ~index:t.st_name
 
-    let value t = Int64.of_int t.st_value
-    let size_in_bytes t = Int64.of_int t.st_size
+    let value t = t.st_value
+    let size_in_bytes t = t.st_size
 
     let type_attribute t =
       match t.st_info land 0xf with
@@ -254,8 +254,8 @@ module Symbol_table = struct
       let st_info = Owee_buf.Read.u8 cursor in
       let st_other = Owee_buf.Read.u8 cursor in
       let st_shndx = Owee_buf.Read.u16 cursor in
-      let st_value = Owee_buf.Read.u64 cursor in
-      let st_size = Owee_buf.Read.u64 cursor in
+      let st_value = Int64.of_int (Owee_buf.Read.u64 cursor) in
+      let st_size = Int64.of_int (Owee_buf.Read.u64 cursor) in
       { st_name; st_info; st_other; st_shndx; st_value; st_size; }
 
     let create buf =
@@ -309,12 +309,12 @@ module Symbol_table = struct
     try
       fold t ~init:[] ~f:(fun sym acc ->
         let sym_start = Symbol.value sym in
-        let sym_end =
-          Int64.add (Symbol.value sym) (Symbol.size_in_bytes sym)
-        in
         if Int64.compare address sym_start < 0 then begin
           raise Symbol_not_found
         end;
+        let sym_end =
+          Int64.add (Symbol.value sym) (Symbol.size_in_bytes sym)
+        in
         if (Int64.compare address sym_start >= 0
             && Int64.compare address sym_end < 0)
           || (Int64.compare address sym_start = 0

--- a/src/owee_elf.ml
+++ b/src/owee_elf.ml
@@ -181,7 +181,6 @@ module Symbol_table = struct
       st_value : Int64.t;
       st_size : Int64.t;
       symbol_end : Int64.t;
-      zero_size : bool;
     }
 
     let struct_size = (32 + 8 + 8 + 16 + 64 + 64) / 8
@@ -246,21 +245,11 @@ module Symbol_table = struct
 
     let section_header_table_index t = t.st_shndx
 
-    let encloses_address t ~address =
-      let sym_start = value t in
-      let compared_to_sym_start = Int64.compare address sym_start in
-      if compared_to_sym_start < 0 then
-        None
-      else
-        let sym_end = t.symbol_end in
-        Some ((compared_to_sym_start >= 0 && Int64.compare address sym_end < 0)
-          || (compared_to_sym_start = 0 && t.zero_size))
+    let symbol_end t = t.symbol_end
   end
 
-  exception Symbol_not_found
-
   module One_table = struct
-    type t = Symbol.t array
+    type t = Symbol.t Owee_interval_tree.t
 
     let extract buf ~index : Symbol.t =
       let cursor = Owee_buf.cursor buf ~at:(index * Symbol.struct_size) in
@@ -270,60 +259,30 @@ module Symbol_table = struct
       let st_shndx = Owee_buf.Read.u16 cursor in
       let st_value = Int64.of_int (Owee_buf.Read.u64 cursor) in
       let st_size = Int64.of_int (Owee_buf.Read.u64 cursor) in
-      let symbol_end = Int64.add st_value st_size in
-      let zero_size =
-        (Int64.compare st_size 0L) = 0
+      let symbol_end =
+        if Int64.compare st_size 0L = 0 then
+          Int64.add st_value 1L
+        else
+          Int64.add st_value st_size
       in
-      { st_name; st_info; st_other; st_shndx; st_value; st_size; symbol_end;
-        zero_size;
-      }
+      { st_name; st_info; st_other; st_shndx; st_value; st_size; symbol_end; }
 
     let create buf =
       let num_symbols = (Owee_buf.dim buf) / Symbol.struct_size in
-      let t = Array.init num_symbols (fun index -> extract buf ~index) in
-      Array.sort (fun sym1 sym2 ->
-          Int64.compare (Symbol.value sym1) (Symbol.value sym2))
-        t;
-      t
+      let interval_array =
+        Array.init num_symbols (fun index ->
+          let symbol = extract buf ~index in
+          Owee_interval_tree.Interval.create
+            (Symbol.value symbol)
+            (Symbol.symbol_end symbol)
+            symbol)
+      in
+      Owee_interval_tree.create (Array.to_list interval_array)
 
-    let num_symbols t = Array.length t
-
-    let get_symbol t ~index =
-      if index < 0 || index >= num_symbols t then None
-      else Some t.(index)
-
-    let get_symbol_exn t ~index =
-      match get_symbol t ~index with
-      | Some symbol -> symbol
-      | None -> failwith "Owee_elf.get_symbol_exn: index out of bounds"
-
-    let iter t ~f =
-      for index = 0 to (num_symbols t) - 1 do
-        f (get_symbol_exn t ~index)
-      done
-
-    let fold t ~init ~f =
-      let acc = ref init in
-      for index = 0 to (num_symbols t) - 1 do
-        acc := f (get_symbol_exn t ~index) !acc
-      done;
-      !acc
-
-    exception Symbol_found of Symbol.t
-
-    (* CR-soon mshinwell: replace by binary search, but it's tricky *)
-    let symbols_enclosing_address_exn ?one_only t ~address =
-      try
-        fold t ~init:[] ~f:(fun sym acc ->
-          match Symbol.encloses_address sym ~address with
-          | None -> raise Symbol_not_found
-          | Some false -> acc
-          | Some true ->
-            match one_only with
-            | None -> sym::acc
-            | Some () -> raise (Symbol_found sym))
-      with
-      | Symbol_found sym -> [sym]
+    let symbols_enclosing_address_exn t ~address =
+      List.map (fun (interval : Symbol.t Owee_interval_tree.Interval.t) ->
+          interval.value)
+        (Owee_interval_tree.query t address)
   end
 
   type t = One_table.t list
@@ -331,30 +290,19 @@ module Symbol_table = struct
   let create bufs =
     List.map (fun buf -> One_table.create buf) bufs
 
-  let iter t ~f =
-    List.iter (fun one_table -> One_table.iter one_table ~f) t
+  let symbols_enclosing_address t ~address =
+    List.fold_left (fun acc one_table ->
+        (One_table.symbols_enclosing_address_exn one_table ~address)
+          @ acc)
+      [] t
 
-  let fold t ~init ~f =
-    List.fold_left (fun init one_table -> One_table.fold one_table ~init ~f)
-      init t
-
-  let symbols_enclosing_address ?one_only t ~address =
-    try
-      List.fold_left (fun acc one_table ->
-          (One_table.symbols_enclosing_address_exn ?one_only one_table
-              ~address)
-            @ acc)
-        [] t
-    with
-    | Symbol_not_found -> []
-
-  let functions_enclosing_address ?one_only t ~address =
+  let functions_enclosing_address t ~address =
     List.filter (fun sym ->
         match Symbol.type_attribute sym with
         | Func -> true
         | Notype | Object | Section | File
         | Common | TLS | GNU_ifunc | Other _ -> false)
-      (symbols_enclosing_address ?one_only t ~address)
+      (symbols_enclosing_address t ~address)
 end
 
 let find_symbol_table buf sections =

--- a/src/owee_elf.ml
+++ b/src/owee_elf.ml
@@ -214,7 +214,7 @@ module Symbol_table = struct
       String_table.get_string string_table ~index:t.st_name
 
     let value t = Int64.of_int t.st_value
-    let size t = Int64.of_int t.st_size
+    let size_in_bytes t = Int64.of_int t.st_size
 
     let type_attribute t =
       match t.st_info land 0xf with
@@ -288,7 +288,9 @@ module Symbol_table = struct
   let symbols_enclosing_address t ~address =
     fold t ~init:[] ~f:(fun sym acc ->
       let sym_start = Symbol.value sym in
-      let sym_end = Int64.add (Symbol.value sym) (Symbol.size sym) in
+      let sym_end =
+        Int64.add (Symbol.value sym) (Symbol.size_in_bytes sym)
+      in
       if Int64.compare address sym_start >= 0
         && Int64.compare address sym_end < 0
       then

--- a/src/owee_elf.mli
+++ b/src/owee_elf.mli
@@ -63,9 +63,11 @@ module String_table : sig
   type t
 
   (* CR-someday mshinwell: [index] should probably be [Int32.t] *)
+  (** Extract a string from the string table at the given index. *)
   val get_string : t -> index:int -> string option
 end
 
+(** Fish out the string table from the given ELF buffer and section array. *)
 val find_string_table : Owee_buf.t -> section array -> String_table.t option
 
 module Symbol_table : sig
@@ -74,7 +76,7 @@ module Symbol_table : sig
   module Symbol : sig
     type t
 
-    type type_attribute =
+    type type_attribute = private
       | Notype
       | Object
       | Func
@@ -85,14 +87,14 @@ module Symbol_table : sig
       | GNU_ifunc
       | Other of int
 
-    type binding_attribute =
+    type binding_attribute = private
       | Local
       | Global
       | Weak
       | GNU_unique
       | Other of int
 
-    type visibility =
+    type visibility = private
       | Default
       | Internal
       | Hidden
@@ -107,12 +109,20 @@ module Symbol_table : sig
     val section_header_table_index : t -> int
   end
 
-  (* CR-someday mshinwell: [int] may not strictly be correct *)
-  val num_symbols : t -> int
-  val get_symbol : t -> index:int -> Symbol.t option
-
   (** Iterate over all symbols in the table. *)
   val iter : t -> f:(Symbol.t -> unit) -> unit
+
+  (** Fold over all symbols in the table. *)
+  val fold : t -> init:'a -> f:(Symbol.t -> 'a -> 'a) -> 'a
+
+  (** The symbols in the table whose value and size determine that they
+      cover [address]. *)
+  val symbols_enclosing_address : t -> address:Int64.t -> Symbol.t list
+
+  (** As for [symbols_enclosing_address], but only returns function
+      symbols. *)
+  val functions_enclosing_address : t -> address:Int64.t -> Symbol.t list
 end
 
+(** Fish out the symbol table from the given ELF buffer and section array. *)
 val find_symbol_table : Owee_buf.t -> section array -> Symbol_table.t option

--- a/src/owee_elf.mli
+++ b/src/owee_elf.mli
@@ -101,8 +101,12 @@ module Symbol_table : sig
       | Protected
 
     val name : t -> String_table.t -> string option
+
+    (** For avoidance of doubt, when [t] is a function symbol, [value]
+        returns the address of the top of the function. *)
     val value : t -> Int64.t
-    val size : t -> Int64.t
+
+    val size_in_bytes : t -> Int64.t
     val type_attribute : t -> type_attribute
     val binding_attribute : t -> binding_attribute
     val visibility : t -> visibility

--- a/src/owee_elf.mli
+++ b/src/owee_elf.mli
@@ -121,12 +121,21 @@ module Symbol_table : sig
   val fold : t -> init:'a -> f:(Symbol.t -> 'a -> 'a) -> 'a
 
   (** The symbols in the table whose value and size determine that they
-      cover [address]. *)
-  val symbols_enclosing_address : t -> address:Int64.t -> Symbol.t list
+      cover [address].  If [one_only] is provided then only at most one
+      symbol is returned. *)
+  val symbols_enclosing_address
+     : ?one_only:unit
+    -> t
+    -> address:Int64.t
+    -> Symbol.t list
 
   (** As for [symbols_enclosing_address], but only returns function
       symbols. *)
-  val functions_enclosing_address : t -> address:Int64.t -> Symbol.t list
+  val functions_enclosing_address
+     : ?one_only:unit
+    -> t
+    -> address:Int64.t
+    -> Symbol.t list
 end
 
 (** Fish out both the dynamic and static symbol tables (.dynsym and .symtab)

--- a/src/owee_elf.mli
+++ b/src/owee_elf.mli
@@ -51,3 +51,68 @@ val section_body : Owee_buf.t -> section -> Owee_buf.t
 
 (** Convenience function to find a section in the section table given its name. *)
 val find_section : section array -> string -> section option
+
+(** Find the body of a section given its name. *)
+val find_section_body
+   : Owee_buf.t
+  -> section array
+  -> section_name:string
+  -> Owee_buf.t option
+
+module String_table : sig
+  type t
+
+  (* CR-someday mshinwell: [index] should probably be [Int32.t] *)
+  val get_string : t -> index:int -> string option
+end
+
+val find_string_table : Owee_buf.t -> section array -> String_table.t option
+
+module Symbol_table : sig
+  type t
+
+  module Symbol : sig
+    type t
+
+    type type_attribute =
+      | Notype
+      | Object
+      | Func
+      | Section
+      | File
+      | Common
+      | TLS
+      | GNU_ifunc
+      | Other of int
+
+    type binding_attribute =
+      | Local
+      | Global
+      | Weak
+      | GNU_unique
+      | Other of int
+
+    type visibility =
+      | Default
+      | Internal
+      | Hidden
+      | Protected
+
+    val name : t -> String_table.t -> string option
+    val value : t -> Int64.t
+    val size : t -> Int64.t
+    val type_attribute : t -> type_attribute
+    val binding_attribute : t -> binding_attribute
+    val visibility : t -> visibility
+    val section_header_table_index : t -> int
+  end
+
+  (* CR-someday mshinwell: [int] may not strictly be correct *)
+  val num_symbols : t -> int
+  val get_symbol : t -> index:int -> Symbol.t option
+
+  (** Iterate over all symbols in the table. *)
+  val iter : t -> f:(Symbol.t -> unit) -> unit
+end
+
+val find_symbol_table : Owee_buf.t -> section array -> Symbol_table.t option

--- a/src/owee_elf.mli
+++ b/src/owee_elf.mli
@@ -71,6 +71,7 @@ end
 val find_string_table : Owee_buf.t -> section array -> String_table.t option
 
 module Symbol_table : sig
+  (** One or more ELF symbol tables, conjoined. *)
   type t
 
   module Symbol : sig
@@ -128,5 +129,6 @@ module Symbol_table : sig
   val functions_enclosing_address : t -> address:Int64.t -> Symbol.t list
 end
 
-(** Fish out the symbol table from the given ELF buffer and section array. *)
+(** Fish out both the dynamic and static symbol tables (.dynsym and .symtab)
+    from the given ELF buffer and section array. *)
 val find_symbol_table : Owee_buf.t -> section array -> Symbol_table.t option

--- a/src/owee_elf.mli
+++ b/src/owee_elf.mli
@@ -114,26 +114,17 @@ module Symbol_table : sig
     val section_header_table_index : t -> int
   end
 
-  (** Iterate over all symbols in the table. *)
-  val iter : t -> f:(Symbol.t -> unit) -> unit
-
-  (** Fold over all symbols in the table. *)
-  val fold : t -> init:'a -> f:(Symbol.t -> 'a -> 'a) -> 'a
-
   (** The symbols in the table whose value and size determine that they
-      cover [address].  If [one_only] is provided then only at most one
-      symbol is returned. *)
+      cover [address]. *)
   val symbols_enclosing_address
-     : ?one_only:unit
-    -> t
+     : t
     -> address:Int64.t
     -> Symbol.t list
 
   (** As for [symbols_enclosing_address], but only returns function
       symbols. *)
   val functions_enclosing_address
-     : ?one_only:unit
-    -> t
+     : t
     -> address:Int64.t
     -> Symbol.t list
 end

--- a/src/owee_interval_tree.ml
+++ b/src/owee_interval_tree.ml
@@ -1,0 +1,160 @@
+(* interval tree for Int64.t intervals, intended usage is to build the tree once
+   then query it many times
+
+   reference:
+
+   @book{ CompGeomThirdEdSpringer,
+   title     = "Computational Geometry: Algorithms and Applications",
+   author    = "M. {de Berg} and O. Cheong and M. {van Kreveld} and
+   M. Overmars",
+   edition   = "Third Edition",
+   pages     = {223--224},
+   doi       = "10.1007/978-3-540-77974-2",
+   year      = "2008",
+   publisher = "Springer"
+   } *)
+
+module Interval : sig
+  (* since bounds are read-only, we don't care about leaving them public *)
+  type 'a t = { lbound : Int64.t ;
+                rbound : Int64.t ;
+                value  : 'a    }
+  val create : Int64.t -> Int64.t -> 'a -> 'a t
+  val of_triplet : Int64.t * Int64.t * 'a -> 'a t
+  val to_triplet : 'a t -> Int64.t * Int64.t * 'a
+end = struct
+  type 'a t = { lbound : Int64.t ;
+                rbound : Int64.t ;
+                value  : 'a    }
+  let create lbound rbound value =
+    assert (lbound <= rbound);
+    { lbound ; rbound ; value }
+  let of_triplet (l, r, v) =
+    create l r v
+  let to_triplet itv =
+    (itv.lbound, itv.rbound, itv.value)
+end
+
+module A   = Array
+module Itv = Interval
+module L   = List
+
+open Itv
+
+type 'a interval_tree =
+  | Empty
+  | Node of
+      (* x_mid left_list       right_list      left_tree          right_tree *)
+      Int64.t *  'a Itv.t list * 'a Itv.t list * 'a interval_tree * 'a interval_tree
+
+type 'a t = 'a interval_tree
+
+(* -------------------- utility functions -------------------- *)
+
+let leftmost_bound_first i1 i2 =
+  compare i1.lbound i2.lbound
+
+let rightmost_bound_first i1 i2 =
+  compare i2.rbound i1.rbound
+
+let is_before interval x_mid =
+  interval.rbound < x_mid
+
+let contains interval x_mid =
+  (interval.lbound <= x_mid) && (x_mid <= interval.rbound)
+
+let bounds_array_of_intervals intervals =
+  let n   = L.length intervals  in
+  let res = A.make (2 * n) 0L   in
+  let i   = ref 0               in
+  L.iter
+    (fun interval ->
+      res.(!i) <- interval.lbound; incr i;
+      res.(!i) <- interval.rbound; incr i)
+    intervals;
+  res
+
+let median xs =
+  A.sort compare xs;
+  let n = A.length xs in
+  if n mod 2 = 1 then
+    xs.(n/2)
+  else
+    Int64.div (Int64.add xs.(n/2) xs.(n/2 - 1)) 2L
+
+let median intervals =
+  let bounds = bounds_array_of_intervals intervals in
+  median bounds
+
+let partition intervals x_mid =
+  let left_intervals, maybe_right_intervals =
+    L.partition
+      (fun interval -> is_before interval x_mid)
+      intervals in
+  let mid_intervals, right_intervals =
+    L.partition
+      (fun interval -> contains interval x_mid)
+      maybe_right_intervals in
+  left_intervals, mid_intervals, right_intervals
+
+(* -------------------- construction -------------------- *)
+
+(* interval tree of a list of intervals
+   WARNING: NOT TAIL REC. *)
+let rec create = function
+  | [] -> Empty
+  | intervals ->
+    let x_mid            = median intervals                 in
+    let left, mid, right = partition intervals x_mid        in
+    let left_list        = L.sort leftmost_bound_first  mid in
+    let right_list       = L.sort rightmost_bound_first mid in
+    Node (x_mid,
+          left_list, right_list,
+          create left, create right)
+
+(* interval tree of a list of interval bounds pairs and values
+   [(lb1, rb1, v1); (lb2, rb2, v2); ...]
+   WARNING: NOT TAIL REC. *)
+let of_triplets triplets =
+  create
+    (L.fold_left
+       (fun acc (l, r, v) -> (Itv.create l r v) :: acc)
+       []
+       triplets)
+
+(* -------------------- query -------------------- *)
+
+(* fold_left f on l while p is true *)
+let rec fold_while f p acc = function
+  | [] -> acc
+  | x :: xs ->
+    if p x then
+      fold_while f p (f x :: acc) xs
+    else
+      acc
+
+let filter_left_list l qx acc =
+  fold_while
+    (fun x -> x)
+    (fun interval -> interval.lbound <= qx)
+    acc l
+
+let filter_right_list l qx acc =
+  fold_while
+    (fun x -> x)
+    (fun interval -> interval.rbound >= qx)
+    acc l
+
+(* find all intervals that contain qx *)
+let query initial_tree qx =
+  let rec query_priv acc = function
+    | Empty -> acc
+    | Node (x_mid, left_list, right_list, left_tree, right_tree) ->
+      if qx < x_mid then
+        let new_acc = filter_left_list  left_list  qx acc in
+        query_priv new_acc left_tree
+      else
+        let new_acc = filter_right_list right_list qx acc in
+        query_priv new_acc right_tree
+  in
+  query_priv [] initial_tree

--- a/src/owee_interval_tree.mli
+++ b/src/owee_interval_tree.mli
@@ -1,0 +1,40 @@
+(** Originally from:
+    https://github.com/UnixJunkie/interval-tree
+    Instead of "Int64.t", we use "Int64.t".
+*)
+
+type 'a t
+
+module Interval : sig
+
+  (** An interval has a left bound, a right bound and a payload (called value) *)
+  type 'a t = { lbound : Int64.t ;
+                rbound : Int64.t ;
+                value  : 'a    }
+
+  (** [create lbound rbound value] create a new Int64.t interval
+      with an associated value.
+      PRECONDITION: [lbound] must be <= [rbound]. *)
+  val create : Int64.t -> Int64.t -> 'a -> 'a t
+
+  (** [of_triplet (lbound, rbound, value)] = [create lbound rbound value] *)
+  val of_triplet : Int64.t * Int64.t * 'a -> 'a t
+
+  (** [to_triplet itv] = [(lbound, rbound, value)] *)
+  val to_triplet : 'a t -> Int64.t * Int64.t * 'a
+end
+
+(** {4 Constructors} *)
+
+(** [create intervals_list] : interval tree of all intervals in the list *)
+val create : 'a Interval.t list -> 'a t
+
+(** [of_triplets interval_triplets] : interval tree of all intervals
+    whose bounds and values are given in a list *)
+val of_triplets : (Int64.t * Int64.t * 'a) list -> 'a t
+
+(** {4 Query} *)
+
+(** [query tree q] : list of intervals in the tree [t] containing
+    the Int64.t [q] *)
+val query : 'a t -> Int64.t -> 'a Interval.t list


### PR DESCRIPTION
Symbol lookup in a naive manner was slow, so I used an interval tree module due to Berenger.  I have added the licence, which appears compatible.
