### PR TITLE
Update to work on OCaml 4.08

### DIFF
--- a/owee.opam
+++ b/owee.opam
@@ -12,4 +12,4 @@ build: [
 depends: [
   "jbuilder" {build}
 ]
-available: [ocaml-version >= "4.02"]
+available: [ocaml-version >= "4.06"]

--- a/src/owee_location.ml
+++ b/src/owee_location.ml
@@ -9,8 +9,10 @@ let myself = lazy begin
   let path = "/proc/" ^ string_of_int pid ^ "/exe" in
   let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
   let len = Unix.lseek fd 0 Unix.SEEK_END in
-  let map = Bigarray.Array1.map_file fd
-      Bigarray.int8_unsigned Bigarray.c_layout false len in
+  let map =
+    Bigarray.array1_of_genarray
+      (Unix.map_file fd Bigarray.int8_unsigned
+         Bigarray.c_layout false [|len|]) in
   Unix.close fd;
   map
 end


### PR DESCRIPTION
Use [Unix.map_file] instead of the removed [Bigarray.Array1.map_file]. Unfortunately, this is incompatible with OCaml < 4.06.

If you want owee to work both on 4.08 and before 4.06 then some kind of configure/conditional compilation will be needed.