### PR TITLE
Remove dynsym section from Symbol_table (issue #3)

### DIFF
--- a/examples/functions.ml
+++ b/examples/functions.ml
@@ -15,10 +15,11 @@ let path, address =
 let buffer =
   let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
   let len = Unix.lseek fd 0 Unix.SEEK_END in
-  let map = Bigarray.Array1.map_file fd
-      Bigarray.int8_unsigned Bigarray.c_layout false len in
+  let map = Unix.map_file
+      fd Bigarray.int8_unsigned Bigarray.c_layout false [|len|]
+  in
   Unix.close fd;
-  map
+  Bigarray.array1_of_genarray map
 
 let _header, sections = Owee_elf.read_elf buffer
 

--- a/src/owee_elf.ml
+++ b/src/owee_elf.ml
@@ -310,11 +310,6 @@ module Symbol_table = struct
 end
 
 let find_symbol_table buf sections =
-  let dynsym = find_section_body buf sections ~section_name:".dynsym" in
-  let symtab = find_section_body buf sections ~section_name:".symtab" in
-  match dynsym, symtab with
-  | None, None -> None
-  | Some dynsym, None -> Some (Symbol_table.create [dynsym])
-  | None, Some symtab -> Some (Symbol_table.create [symtab])
-  | Some dynsym, Some symtab ->
-    Some (Symbol_table.create [dynsym; symtab])
+  match find_section_body buf sections ~section_name:".symtab" with
+  | None -> None
+  | Some symtab -> Some (Symbol_table.create [symtab])


### PR DESCRIPTION
This fixes issue #3. 
There is still some redundancy in the output of example/functions because iteration is done on intervals and not on individual symbols. This can probably be fixed by changing the data structure representing symbols, I am tempted to simplify the whole thing unless there are evidence that an interval tree or equivalent structure is necessary for performance.