### PR TITLE
Add copy of mutable state in owee_debug_line

### DIFF
--- a/src/owee_debug_line.ml
+++ b/src/owee_debug_line.ml
@@ -239,3 +239,18 @@ let rec fold_rows header section state f acc =
 
 let fold_rows (header,section) f acc =
   fold_rows header section (initial_state header) f acc
+
+let copy state =
+  { address = state.address;
+    filename = state.filename;
+    file = state.file;
+    line = state.line;
+    col = state.col;
+    is_statement = state.is_statement;
+    basic_block = state.basic_block;
+    end_sequence = state.end_sequence;
+    prologue_end = state.prologue_end;
+    epilogue_begin = state.epilogue_begin;
+    isa = state.isa;
+    discriminator = state.discriminator;
+  }

--- a/src/owee_debug_line.mli
+++ b/src/owee_debug_line.mli
@@ -10,7 +10,9 @@ type header
 *)
 val read_chunk : cursor -> (header * cursor) option
 
-(** State of the linenumber automaton *)
+(** State of the linenumber automaton.
+    IMPORTANT: this state is mutable!
+    A value of this type can change as the file is scanned. *)
 type state = {
   mutable address        : int;
   mutable filename       : string;
@@ -38,3 +40,6 @@ val get_filename : header -> state -> string option
     initial state [init]. *)
 val fold_rows : header * cursor ->
   (header -> state -> 'a -> 'a) -> 'a -> 'a
+
+(** [copy state] returns a copy of the mutable state *)
+val copy : state -> state


### PR DESCRIPTION
Sometimes we need to know both the previous and the current debug lines, but the state of owee_debug_line is mutable and changes during the traversal, so a copy of the state is needed. This PR proposes to add a copy function to the interface (instead of implementing it in the client). 