### PR TITLE
Owee_buf.zero_string delete the first argument and return an option

### DIFF
--- a/src/owee_buf.ml
+++ b/src/owee_buf.ml
@@ -114,23 +114,25 @@ module Read = struct
     advance t length;
     Bytes.unsafe_to_string result
 
-  let rec scan_0 msg (b : t) ofs l i =
+  let rec scan_0 (b : t) ofs l i =
     if i >= l then
-      invalid_format msg
+      None
     else if b.{ofs + i} = 0 then
-      i
+      Some i
     else
-      scan_0 msg b ofs l (i + 1)
+      scan_0 b ofs l (i + 1)
 
-  let zero_string msg t ?maxlen () =
+  let zero_string t ?maxlen () =
     let maxlen = match maxlen with
       | None -> dim t.buffer - t.position
       | Some maxlen -> maxlen
     in
-    let length = scan_0 msg t.buffer t.position maxlen 0 in
-    let result = fixed_string t length in
-    advance t 1;
-    result
+    match scan_0 t.buffer t.position maxlen 0 with
+    | None -> None
+    | Some length ->
+      let result = fixed_string t length in
+      advance t 1;
+      Some result
 
   let buffer t length =
     let result = Bigarray.Array1.sub t.buffer t.position length in

--- a/src/owee_buf.mli
+++ b/src/owee_buf.mli
@@ -56,10 +56,9 @@ module Read : sig
   (** [fixed_string t len] reads a string of exactly [len] bytes from [t] *)
   val fixed_string : cursor -> int -> string
 
-  (** [zero_string msg t ?maxlen ()] reads a zero-terminated string from [t],
+  (** [zero_string t ?maxlen ()] reads a zero-terminated string from [t],
       stopping at the first zero or when [maxlen] is reached, if it was provided. *)
-  (* CR mshinwell: delete the first argument and return an option *)
-  val zero_string : string -> cursor -> ?maxlen:int -> unit -> string
+  val zero_string : cursor -> ?maxlen:int -> unit -> string option
 
   val buffer : cursor -> int -> t
 end

--- a/src/owee_debug_line.ml
+++ b/src/owee_debug_line.ml
@@ -15,20 +15,26 @@ type header = {
 }
 
 let read_filename t =
-  match Read.zero_string "Unterminated filename" t () with
-  | "" -> ""
-  | fname ->
-    let _dir  = Read.uleb128 t in
-    let _time = Read.uleb128 t in
-    let _len  = Read.uleb128 t in
-    fname
+  match Read.zero_string t () with
+  | None -> invalid_format "Unterminated filename"
+  | Some s ->
+    match s with
+    | "" -> ""
+    | fname ->
+      let _dir  = Read.uleb128 t in
+      let _time = Read.uleb128 t in
+      let _len  = Read.uleb128 t in
+      fname
 
 let rec skip_directories t =
-  match Read.zero_string "Unterminated directory list" t () with
-  | "" -> ()
-  | _dir ->
-    (*print_endline _dir;*)
-    skip_directories t
+  match Read.zero_string t () with
+  | None -> invalid_format "Unterminated directory list"
+  | Some s ->
+    match s with
+    | "" -> ()
+    | _dir ->
+      (*print_endline _dir;*)
+      skip_directories t
 
 let rec read_filenames acc t = match read_filename t with
   | "" -> Array.of_list (List.rev acc)

--- a/src/owee_elf.ml
+++ b/src/owee_elf.ml
@@ -121,8 +121,9 @@ let read_section header t n =
 let read_section_name shstrndx t shdr =
   let n = shdr.sh_name in
   seek t (shstrndx.sh_offset + n);
-  Read.zero_string "Unterminated section name" t
-    ~maxlen:(shstrndx.sh_size - n) ()
+  match Read.zero_string t ~maxlen:(shstrndx.sh_size - n) () with
+  | None -> invalid_format "Unterminated section name"
+  | Some s -> s
 
 let read_sections header t =
   let sections = Array.init header.e_shnum (read_section header t) in
@@ -165,7 +166,7 @@ module String_table = struct
       None
     else
       let cursor = Owee_buf.cursor t ~at:index in
-      Some (Owee_buf.Read.zero_string "boo!" cursor ())
+      Owee_buf.Read.zero_string cursor ()
 end
 
 let find_string_table buf sections =

--- a/src/owee_macho.ml
+++ b/src/owee_macho.ml
@@ -9,7 +9,9 @@ let rec decode_flags n acc = function
 
 let read_lc_string buf t =
   let offset = Read.u32 t in
-  Read.zero_string "invalid lc_string" (cursor buf ~at:offset) ()
+  match Read.zero_string (cursor buf ~at:offset) () with
+  | None -> invalid_format "invalid lc_string"
+  | Some s -> s
 
 type magic =
   | MAGIC32
@@ -748,7 +750,9 @@ type symbol = {
 
 let read_symbol_name t buf =
   let offset = Read.u32 t in
-  Read.zero_string "invalid symbol name" (cursor buf ~at:offset) ()
+  match Read.zero_string (cursor buf ~at:offset) () with
+  | None -> invalid_format "invalid symbol name"
+  | Some s -> s
 
 type dylib_module = {
   (*  module name string table offset *)
@@ -1130,7 +1134,9 @@ let read_uuid_command t =
 
 let read_rpath_command buf t =
   let offset = Read.u32 t in
-  LC_RPATH (Read.zero_string "invalid rpath" (cursor buf ~at:offset) ())
+  match Read.zero_string (cursor buf ~at:offset) () with
+  | None -> invalid_format "invalid rpath"
+  | Some s -> LC_RPATH s
 
 let read_link_edit t k =
   let dataoff  = Read.u32 t in


### PR DESCRIPTION
This is a simple change that simplifies the interface of owee_buf and the code of scan_0. There isn't a strong motivation for it, other than to address a previous CR comment (encountered while I was making some unrelated changes).