### PR TITLE
Convert u64 from int to int64

### DIFF
--- a/src/owee_buf.ml
+++ b/src/owee_buf.ml
@@ -71,21 +71,14 @@ module Read = struct
   let u32be = u32
 
   let u64 t : u64 =
-    let result = List.fold_left
-                   (fun acc n -> Int64.logor acc (Int64.of_int n))
-                   0L
-                   [ t.buffer.{t.position};
-                     t.buffer.{t.position + 1} lsl 8;
-                     t.buffer.{t.position + 2} lsl 16;
-                     t.buffer.{t.position + 3} lsl 24;
-                     t.buffer.{t.position + 4} lsl 32;
-                     t.buffer.{t.position + 5} lsl 40;
-                     t.buffer.{t.position + 6} lsl 48;
-                     t.buffer.{t.position + 7} lsl 56
-                   ]
-    in
+    let result = ref 0L in
+    for i = 0 to 7 do
+      let open Int64 in
+      let n = of_int t.buffer.{t.position + i} in
+      result := logor !result (shift_left n (i * 8))
+    done;
     advance t 8;
-    result
+    !result
 
   let uleb128 t : u128 =
     let rec aux t shift acc =

--- a/src/owee_buf.mli
+++ b/src/owee_buf.mli
@@ -3,26 +3,24 @@
 type t =
   (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
+(* Size of buffer remains int, because the size (aka dim) of
+   Bigarray.Array1 is int, not int64. It should be enough in practice,
+   as we will not be able to manipulate larger binaries anyway. *)
 (** Size of the buffer *)
-(* CR mshinwell: rename to "size" *)
-val dim     : t -> int
+val size     : t -> int
 
 (** Minimal support for error reporting. FIXME: Improve that someday. *)
 exception Invalid_format of string
 val invalid_format : string -> 'a
 val assert_format : bool -> string -> unit
 
-(* Some aliases to make more explicit the nature of values being read ...
-   FIXME: As a first approximation, all values are expected to fit in OCaml
-   integers.
-*)
+(* Some aliases to make more explicit the nature of values being read. *)
 type s8   = int
 type u8   = int
 type u16  = int
 type s32  = int
 type u32  = int
-(* CR mshinwell: u64 should be Int64.t *)
-type u64  = int (* Bye bye 32 bits. 63 bits ought to be enough for anyone. *)
+type u64  = int64
 type s128 = int (* Ahem, we don't expect 128 bits to really consume 128 bits *)
 type u128 = int
 


### PR DESCRIPTION
This PR changes the implementation of u64 from int to int64 to accommodate large values correctly when reading them from elf headers, etc. Note that addresses into binaries are still represented as int (not converted to int64), because (a) the size of Bigarray.Array1 is int, and (b) it's impossible to create such larger binaries anyway, let alone
manipulate them. 

There might be a performance penalty from this change. This version has more allocation (boxed int64) and extra conversions back and forth between int addresses and int64 values. In practice, I used it to read large elf binaries and haven't noticed anything dramatic in the client of owee. I haven't measured performance impact of this change on its own. I am happy to do it if this is a concern.

This PR also makes a trivial change along the way: rename Owee_debug_line.dim to size, to address a previous CR comment.