### PR TITLE
Fixed code fragment lookup for 4.12

### DIFF
--- a/src/owee_stubs.c
+++ b/src/owee_stubs.c
@@ -4,6 +4,7 @@
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/address_class.h>
+#include <caml/codefrag.h>
 
 /* Use dladdr. Should work at least with Linux, FreeBSD and OS X. */
 #define _GNU_SOURCE
@@ -44,7 +45,8 @@ static void *closure_code_pointer(value closure)
   for (i = 1; i < Wosize_val(closure); ++i)
   {
     void *cp2 = (void*)Field(closure, i);
-    if (cp2 >= (void*)caml_code_area_start && cp2 <= (void*)caml_code_area_end)
+    struct code_fragment *cf = caml_find_code_fragment_by_pc(cp2);
+    if (cf != NULL)
       return cp2;
   }
 


### PR DESCRIPTION
4.12 does not expose code_area_start/end any more, relying instead on a separate map.