### PR TITLE
Parse elf notes for stapsdt probes and buildid

### DIFF
--- a/examples/decodedline_elf.ml
+++ b/examples/decodedline_elf.ml
@@ -8,13 +8,7 @@ let path =
   else
     Sys.argv.(1)
 
-let buffer =
-  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
-  let len = Unix.lseek fd 0 Unix.SEEK_END in
-  let map = Bigarray.Array1.map_file fd
-      Bigarray.int8_unsigned Bigarray.c_layout false len in
-  Unix.close fd;
-  map
+let buffer = Owee_buf.map_binary path
 
 let _header, sections = Owee_elf.read_elf buffer
 

--- a/examples/decodedline_macho.ml
+++ b/examples/decodedline_macho.ml
@@ -8,13 +8,7 @@ let path =
   else
     Sys.argv.(1)
 
-let buffer =
-  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
-  let len = Unix.lseek fd 0 Unix.SEEK_END in
-  let map = Bigarray.Array1.map_file fd
-      Bigarray.int8_unsigned Bigarray.c_layout false len in
-  Unix.close fd;
-  map
+let buffer = Owee_buf.map_binary path
 
 let _header, commands = Owee_macho.read buffer
 
@@ -28,7 +22,7 @@ let iter_sections f segment =
   Array.iter (f segment) segment.Owee_macho.seg_sections
 
 let debug_section segment = function
-  | {Owee_macho.sec_sectname = "__debug_line"; sec_segname = "__DWARF"}
+  | {Owee_macho.sec_sectname = "__debug_line"; sec_segname = "__DWARF"; _}
     as section ->
     let body = Owee_buf.cursor (Owee_macho.section_body buffer segment section) in
     let rec aux () =

--- a/examples/dune
+++ b/examples/dune
@@ -1,7 +1,8 @@
 (executables
- (names decodedline_elf decodedline_macho functions)
+ (names decodedline_elf decodedline_macho functions read_buildid read_stapsdt_probes)
  (libraries owee unix))
 
 (alias
  (name examples)
- (deps decodedline_elf.exe decodedline_macho.exe))
+ (deps decodedline_elf.exe decodedline_macho.exe
+       read_buildid.exe read_stapsdt_probes.exe))

--- a/examples/read_buildid.ml
+++ b/examples/read_buildid.ml
@@ -1,0 +1,13 @@
+let () =
+  let path =
+    if not (Array.length Sys.argv = 2)
+    then (
+      prerr_endline ("Usage: " ^ Sys.argv.(0) ^ " my_binary.elf");
+      exit 1)
+    else Sys.argv.(1)
+  in
+  let buffer = Owee_buf.map_binary path in
+  let _header, sections = Owee_elf.read_elf buffer in
+  let buildid = Owee_elf_notes.read_buildid buffer sections in
+  Printf.printf "%s\n" buildid
+;;

--- a/examples/read_stapsdt_probes.ml
+++ b/examples/read_stapsdt_probes.ml
@@ -1,0 +1,21 @@
+let () =
+  let path =
+    if not (Array.length Sys.argv = 2)
+    then (
+      prerr_endline ("Usage: " ^ Sys.argv.(0) ^ " my_binary.elf");
+      exit 1)
+    else Sys.argv.(1)
+  in
+  let buffer = Owee_buf.map_binary path in
+  let _header, sections = Owee_elf.read_elf buffer in
+  let f (p : Owee_elf_notes.Stapsdt.t) =
+    Printf.printf
+      "addr=0x%Lx %s %s %s semaphore=0x%Lx\n"
+      p.addr
+      p.provider
+      p.name
+      p.args
+      (Option.value p.semaphore ~default:0L)
+  in
+  Owee_elf_notes.Stapsdt.iter buffer sections ~f
+;;

--- a/src/owee_buf.ml
+++ b/src/owee_buf.ml
@@ -8,6 +8,16 @@ type cursor = {
   mutable position: int;
 }
 
+let map_binary path =
+  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+  let len = Unix.lseek fd 0 Unix.SEEK_END in
+  let t =
+    Bigarray.array1_of_genarray
+      (Unix.map_file fd Bigarray.int8_unsigned
+         Bigarray.c_layout false [|len|]) in
+  Unix.close fd;
+  t
+
 exception Invalid_format of string
 let invalid_format msg = raise (Invalid_format msg)
 

--- a/src/owee_buf.mli
+++ b/src/owee_buf.mli
@@ -3,6 +3,8 @@
 type t =
   (int, Bigarray.int8_unsigned_elt, Bigarray.c_layout) Bigarray.Array1.t
 
+val map_binary : string -> t
+
 (* Size of buffer remains int, because the size (aka dim) of
    Bigarray.Array1 is int, not int64. It should be enough in practice,
    as we will not be able to manipulate larger binaries anyway. *)

--- a/src/owee_elf_notes.ml
+++ b/src/owee_elf_notes.ml
@@ -1,0 +1,199 @@
+type header = {
+  owner : string;
+  typ : int;  (** each owner defines its own types *)
+  size : int;
+}
+
+module Read = Owee_buf.Read
+
+(* Align size to 4 bytes as needed for note name and descriptor data. *)
+let padding n = (4 - (n land 3)) land 3
+
+(* Advance the cursor over padding.
+
+   "Padding is present, if necessary, to ensure 4-byte alignment for
+   the descriptor. Such padding is not included in namesz. [...]
+   Padding is present, if necessary, to ensure 4-byte alignment for
+   the next note entry. Such padding is not included in descsz."
+   From "Tool Interface Standard (TIS)
+   Executable and Linking Format (ELF) Specification" *)
+let gulp_padding cursor size =
+  let unread = padding size in
+  if unread > 0 then begin
+    Owee_buf.ensure cursor unread "Not found padding after note name";
+    Owee_buf.advance cursor unread
+  end
+
+let check_string_length size str =
+  let len = String.length str + (* terminating zero char *) 1 in
+  if not (len = size) then
+    Owee_buf.invalid_format
+      (Printf.sprintf "Unexpected length of %s instead of %d\n" str size)
+
+let read_desc_size cursor ~expected_owner ~expected_type =
+  Owee_buf.ensure cursor (4 * 3) "Note header truncated";
+  let namesz = Read.u32 cursor in
+  check_string_length namesz expected_owner;
+  let descsz = Read.u32 cursor in
+  let typ = Read.u32 cursor in
+  if not (typ = expected_type) then
+    Owee_buf.invalid_format
+      (Printf.sprintf "Unexpected note type %d instead of %d\n"
+         typ expected_type);
+  Owee_buf.ensure cursor namesz "Note owner name truncated";
+  (match Read.zero_string cursor ~maxlen:namesz () with
+   | None ->
+     Owee_buf.invalid_format
+       (Printf.sprintf "Cannot read note owner of length %d\n" namesz)
+   | Some owner ->
+     if not (String.equal owner expected_owner) then
+       Owee_buf.invalid_format
+         (Printf.sprintf "Unexpected note owner %s instead of %s\n"
+            owner expected_owner));
+  gulp_padding cursor namesz;
+  Owee_buf.ensure cursor descsz
+    (Printf.sprintf "Cannot read note description of size %d\n" descsz);
+  descsz
+
+let read_header cursor =
+  Owee_buf.ensure cursor (4 * 3) "Note header truncated";
+  let namesz = Read.u32 cursor in
+  let descsz = Read.u32 cursor in
+  let typ = Read.u32 cursor in
+  Owee_buf.ensure cursor namesz "Note owner name truncated";
+  let owner =
+    match Read.zero_string cursor ~maxlen:namesz () with
+   | None ->
+     Owee_buf.invalid_format
+       (Printf.sprintf "Cannot read owner of length %d\n" namesz)
+   | Some str ->
+     check_string_length namesz str;
+     str
+  in
+  gulp_padding cursor namesz;
+  Owee_buf.ensure cursor descsz
+    (Printf.sprintf "Cannot read note description of size %d\n" descsz);
+  { owner;
+    size = descsz;
+    typ;
+  }
+
+let find_notes_section sections name =
+  match Owee_elf.find_section sections name with
+  | None ->
+    Owee_buf.invalid_format ("Not found section "^name)
+  | Some s ->
+    match s.sh_type with
+    | 7 (* SHT_NOTE *) -> s
+    | _ ->
+      Owee_buf.invalid_format
+        (Printf.sprintf "Unexpected type %d of %s section, instead of SHT_NOTE=7\n"
+           s.sh_type s.sh_name_str)
+
+module Stapsdt = struct
+  type t =
+    { addr : int64 (** address of the probe site *)
+    ; semaphore : int64 option (** address of the semaphore corresponding to the probe *)
+    ; provider : string
+    ; name : string
+    ; args : string (** probe arguments  *)
+    }
+
+  (* Arguments can be tricky to parse: [s] can be empty or ":" or space separated list of
+     N@OP, but OP can have spaces in it and "N@" may be missing.
+
+     CR-someday gyorsh: implement full parsing? *)
+
+  (* Adjust for the prelink effect.  [actual_base] is the start address of the .stapsdt.base
+     section in ELF file, and [recorded_base] is the address of that section as it appears
+     in the note. They may be different if there is prelink, because prelink does not adjust
+     notes' content for address offsets. *)
+  let adjust addr ~actual_base ~recorded_base =
+    Int64.add (Int64.sub actual_base recorded_base) addr
+
+  let read cursor ~actual_base =
+    let descsz = read_desc_size
+                 ~expected_owner:"stapsdt"
+                 ~expected_type:3 (* stapsdt v3 *)
+                 cursor
+    in
+    if descsz < 8 * 3
+    then Owee_buf.invalid_format
+           (Printf.sprintf "Too small size of note %d\n" descsz);
+    let addr = Read.u64 cursor in
+    let recorded_base = Read.u64 cursor in
+    let semaphore =
+      let n = Read.u64 cursor in
+      if Int64.equal n 0L then None else Some n
+    in
+    let maxlen = descsz - (8 * 3) in
+    let provider =
+      match Read.zero_string cursor ~maxlen () with
+      | None -> Owee_buf.invalid_format "Cannot read probe provider"
+      | Some s -> s
+    in
+    let maxlen = maxlen - String.length provider - 1 in
+    let name =
+      match Read.zero_string cursor ~maxlen () with
+      | None -> Owee_buf.invalid_format "Cannot read probe name"
+      | Some s -> s
+    in
+    let maxlen = maxlen - String.length name - 1 in
+    let args =
+      match Read.zero_string cursor ~maxlen () with
+      | None -> Owee_buf.invalid_format "Cannot read probe's arguments"
+      | Some s -> s
+    in
+    (* skip padding of description to 4-byte boundary *)
+    gulp_padding cursor descsz;
+    { addr = adjust addr ~actual_base ~recorded_base
+    ; semaphore = Option.map (adjust ~actual_base ~recorded_base) semaphore
+    ; provider
+    ; name
+    ; args
+    }
+
+  let iter map sections ~f =
+    let s = find_notes_section sections ".note.stapsdt" in
+    match Owee_elf.find_section sections ".stapsdt.base" with
+    | None ->
+      Owee_buf.invalid_format
+        (Printf.sprintf
+           "Found .note.stapsdt but not .stapsdt.base section\n")
+    | Some base_section ->
+      let body = Owee_elf.section_body map s in
+      let cursor = Owee_buf.cursor body in
+      while not (Owee_buf.at_end cursor) do
+        let note = read cursor ~actual_base:base_section.sh_addr in
+        f note
+      done
+end
+
+let char_hex n =
+  Char.unsafe_chr (n + if n < 10 then Char.code '0' else (Char.code 'a' - 10))
+
+let hex_to_string cursor size =
+  (* read desc byte by byte and convert hex to string *)
+  let result = Bytes.create (size*2) in
+  for i = 0 to size - 1 do
+    let x = Read.u8 cursor in
+    Bytes.unsafe_set result (i*2) (char_hex (x lsr 4));
+    Bytes.unsafe_set result (i*2+1) (char_hex (x land 0x0f));
+  done;
+  Bytes.unsafe_to_string result
+
+let read_buildid map sections =
+  let s = find_notes_section sections ".note.gnu.build-id" in
+  let body = Owee_elf.section_body map s in
+  let cursor = Owee_buf.cursor body in
+  let descsz = read_desc_size cursor
+                 ~expected_owner:"GNU"
+                 ~expected_type:(* NT_GNU_BUILD_ID *) 3 in
+  let buildid = hex_to_string cursor descsz in
+  gulp_padding cursor descsz;
+  if not (Owee_buf.at_end cursor) then
+    Owee_buf.invalid_format "Unexpected data after buildid";
+  buildid
+
+
+

--- a/src/owee_elf_notes.mli
+++ b/src/owee_elf_notes.mli
@@ -1,0 +1,41 @@
+type header = {
+  owner : string;
+  typ : int;  (** each owner defines its own types *)
+  size : int;  (** size of the note's descriptor that follows the header  *)
+}
+
+val read_header : Owee_buf.cursor -> header
+
+(** Reads the header and returns the size of the note's descriptor.
+    Raises if the [expected_owner] or [expected_type] does not match the header. *)
+val read_desc_size
+  : Owee_buf.cursor
+  -> expected_owner:string
+  -> expected_type:int
+  -> int
+
+module Stapsdt : sig
+  type t =
+    { addr : int64 (** address of the probe site *)
+    ; semaphore : int64 option (** address of the semaphore corresponding to the probe *)
+    ; provider : string
+    ; name : string
+    ; args : string (** probe arguments  *)
+    }
+
+  (** [iter buf sections ~f] applies [f] to each stapsdt note,
+      in order of appearance in .notes.stapsdt section.
+      Expects [buf] to point to the beginning of an elf file.
+      Raises .note.stapsdt section is not found.
+      Raises if .note.stapsdt is found but .stapsdt.base is not.
+      Raises if the owner is not "stapsdt" or the type is not 3
+      for version 3 of probes.
+      Raises if parsing of notes fails for other reasons. *)
+  val iter : Owee_buf.t -> Owee_elf.section array -> f:(t -> unit) -> unit
+end
+
+(** [get_buildid buf sections]
+    Reads ".note.gnu.build-id" section, checks that the owner is "GNU"
+    and that the type is NT_GNU_BUILD_ID=3 and returns the content.
+    Expects [buf] to point to the beginning of an elf file. *)
+val read_buildid : Owee_buf.t -> Owee_elf.section array -> string

--- a/src/owee_location.ml
+++ b/src/owee_location.ml
@@ -3,16 +3,6 @@ type t
 external extract : (_ -> _) -> t =
   "ml_owee_code_pointer" "ml_owee_code_pointer" "noalloc"
 
-let map_binary path =
-  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
-  let len = Unix.lseek fd 0 Unix.SEEK_END in
-  let map =
-    Bigarray.array1_of_genarray
-      (Unix.map_file fd Bigarray.int8_unsigned
-         Bigarray.c_layout false [|len|]) in
-  Unix.close fd;
-  map
-
 let count_rows body =
   let open Owee_debug_line in
   let cursor = Owee_buf.cursor body in
@@ -97,7 +87,7 @@ let memory_map = lazy begin try
       try Hashtbl.find slots pathname
       with Not_found ->
         let slot = lazy (
-          try pathname |> map_binary |> extract_debug_info
+          try pathname |> Owee_buf.map_binary |> extract_debug_info
           with exn ->
             prerr_endline ("Owee: fail to parse binary " ^ pathname ^ ": " ^
                            Printexc.to_string exn);


### PR DESCRIPTION
I added examples that demonstrate the new features:

- read GNU buildid of ELF binary

- read SystemTap notes describing tracing probes available in ELF binary