### PR TITLE
Section_not_found exception for Elf notes

### DIFF
--- a/src/owee_elf_notes.ml
+++ b/src/owee_elf_notes.ml
@@ -78,10 +78,11 @@ let read_header cursor =
     typ;
   }
 
+exception Section_not_found of string
+
 let find_notes_section sections name =
   match Owee_elf.find_section sections name with
-  | None ->
-    Owee_buf.invalid_format ("Not found section "^name)
+  | None -> raise (Section_not_found name)
   | Some s ->
     match s.sh_type with
     | 7 (* SHT_NOTE *) -> s

--- a/src/owee_elf_notes.mli
+++ b/src/owee_elf_notes.mli
@@ -14,6 +14,8 @@ val read_desc_size
   -> expected_type:int
   -> int
 
+exception Section_not_found of string
+
 module Stapsdt : sig
   type t =
     { addr : int64 (** address of the probe site *)
@@ -26,7 +28,7 @@ module Stapsdt : sig
   (** [iter buf sections ~f] applies [f] to each stapsdt note,
       in order of appearance in .notes.stapsdt section.
       Expects [buf] to point to the beginning of an elf file.
-      Raises .note.stapsdt section is not found.
+      Raises [Section_not_found] if .note.stapsdt section is not found.
       Raises if .note.stapsdt is found but .stapsdt.base is not.
       Raises if the owner is not "stapsdt" or the type is not 3
       for version 3 of probes.


### PR DESCRIPTION
If there is no section named `.note.stapsdt`, raise `Section_not_found` exception instead of `Invalid_format`, because this section is optional. The new exception makes it easier to use `Owee_elf_notes` module. 