### PR TITLE
Partially support DWARF 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,20 @@ Owee is an experimental library to work with DWARF format.
 
 OCaml users might find the `Owee_location` module interesting.
 
-Provided you:
-- use Linux,
-- on 64-bit x86 architecture,
-- generated debugging symbols,
-- compiled in native code,
-- no relocation happened and you're not using `Dynlink`
+Provided an executable:
+
+- runs on Linux,
+- runs on a 64-bit x86 architecture,
+- contains debug symbols generated with DWARF 2 to DWARF 4,
+- contains native code,
+- is not relocated, and
+- does not use `Dynlink`.
 
 Then it gives you the location of the definition of an arbitrary functional
 value. Linking the library is enough, no change to the toolchain is required.
 
-These restrictions can be relaxed, open issues for platform you'd find interesting to support & on which you can test the library.
+There is partial support for DWARF 5; only symbol names and filenames are fully
+tested.
+
+These restrictions can be relaxed. Open issues for platform you'd find
+interesting to support & on which you can test the library.

--- a/src/owee_debug_line.mli
+++ b/src/owee_debug_line.mli
@@ -2,13 +2,24 @@ open Owee_buf
 
 type header
 
-(** [read_chunk cursor] expects cursor to be pointing to the beginning of a
-    DWARF linenumber program.  Those are usually put in ".debug_line" section
-    of an ELF binary.
+type pointers_to_other_sections = {
+  debug_line_str : t option;
+  debug_str      : t option;
+}
+
+(** [read_chunk cursor ~pointers_to_other_sections] expects the [cursor] to be
+    pointing to the beginning of a DWARF linenumber program. Those are usually
+    put in ".debug_line" section of an ELF binary.
+
     Iff such a program is found, the [cursor] is advanced to the next one (or
     to the end) and [Some (header, cursor')] is returned.
-*)
-val read_chunk : cursor -> (header * cursor) option
+
+    [pointers_to_other_sections] are needed in DWARF 5 because filenames can be
+    pointers to strings in entirely separate sections of DWARF. *)
+val read_chunk
+  :  cursor
+  -> pointers_to_other_sections:pointers_to_other_sections
+  -> (header * cursor) option
 
 (** State of the linenumber automaton.
     IMPORTANT: this state is mutable!

--- a/src/owee_elf.ml
+++ b/src/owee_elf.ml
@@ -173,6 +173,20 @@ end
 let find_string_table buf sections =
   find_section_body buf sections ~section_name:".strtab"
 
+let debug_line_pointers buf sections =
+  { Owee_debug_line.
+     debug_line_str =
+       find_section_body
+         buf
+         sections
+         ~section_name:".debug_line_str";
+     debug_str =
+       find_section_body
+         buf
+         sections
+         ~section_name:".debug_str";
+   }
+
 module Symbol_table = struct
   module Symbol = struct
     type t = {

--- a/src/owee_elf.mli
+++ b/src/owee_elf.mli
@@ -45,19 +45,24 @@ type section = {
     section table. *)
 val read_elf : Owee_buf.t -> header * section array
 
-(** [section_body elf section] returns a sub-buffer with the contents of the
-    [section] of the ELF image. *)
+(** From a buffer pointing to an ELF image, [section_body elf section] returns
+    a sub-buffer with the contents of the [section] of the ELF image. *)
 val section_body : Owee_buf.t -> section -> Owee_buf.t
 
 (** Convenience function to find a section in the section table given its name. *)
 val find_section : section array -> string -> section option
 
-(** Find the body of a section given its name. *)
+(** From a buffer pointing to an ELF image, find the body of a section given its name. *)
 val find_section_body
    : Owee_buf.t
   -> section array
   -> section_name:string
   -> Owee_buf.t option
+
+val debug_line_pointers
+  : Owee_buf.t
+  -> section array
+  -> Owee_debug_line.pointers_to_other_sections
 
 module String_table : sig
   type t

--- a/src/owee_form.ml
+++ b/src/owee_form.ml
@@ -1,0 +1,199 @@
+open Owee_buf
+
+type t =
+  [ `addr
+  | `block2
+  | `block4
+  | `data2
+  | `data4
+  | `data8
+  | `string
+  | `block
+  | `block1
+  | `data1
+  | `flag
+  | `sdata
+  | `strp
+  | `udata
+  | `ref_addr
+  | `ref1
+  | `ref2
+  | `ref4
+  | `ref8
+  | `ref_udata
+  | `indirect
+  | `sec_offset
+  | `exprloc
+  | `flag_present
+  | `strx
+  | `addrx
+  | `ref_sup4
+  | `strp_sup
+  | `data16
+  | `line_strp
+  | `ref_sig8
+  | `implicit_const
+  | `loclistx
+  | `rnglistx
+  | `ref_sup8
+  | `strx1
+  | `strx2
+  | `strx3
+  | `strx4
+  | `addrx1
+  | `addrx2
+  | `addrx3
+  | `addrx4
+  ]
+
+let of_int_exn = function
+  | 0x01 -> `addr
+  | 0x03 -> `block2
+  | 0x04 -> `block4
+  | 0x05 -> `data2
+  | 0x06 -> `data4
+  | 0x07 -> `data8
+  | 0x08 -> `string
+  | 0x09 -> `block
+  | 0x0a -> `block1
+  | 0x0b -> `data1
+  | 0x0c -> `flag
+  | 0x0d -> `sdata
+  | 0x0e -> `strp
+  | 0x0f -> `udata
+  | 0x10 -> `ref_addr
+  | 0x11 -> `ref1
+  | 0x12 -> `ref2
+  | 0x13 -> `ref4
+  | 0x14 -> `ref8
+  | 0x15 -> `ref_udata
+  | 0x16 -> `indirect
+  | 0x17 -> `sec_offset
+  | 0x18 -> `exprloc
+  | 0x19 -> `flag_present
+  | 0x1a -> `strx
+  | 0x1b -> `addrx
+  | 0x1c -> `ref_sup4
+  | 0x1d -> `strp_sup
+  | 0x1e -> `data16
+  | 0x1f -> `line_strp
+  | 0x20 -> `ref_sig8
+  | 0x21 -> `implicit_const
+  | 0x22 -> `loclistx
+  | 0x23 -> `rnglistx
+  | 0x24 -> `ref_sup8
+  | 0x25 -> `strx1
+  | 0x26 -> `strx2
+  | 0x27 -> `strx3
+  | 0x28 -> `strx4
+  | 0x29 -> `addrx1
+  | 0x2a -> `addrx2
+  | 0x2b -> `addrx3
+  | 0x2c -> `addrx4
+  | _    -> failwith "invalid form code"
+
+let read cursor =
+  of_int_exn (Read.uleb128 cursor)
+
+let rec skip t cursor ~is_64bit ~address_size =
+  match t with
+  | ( `flag_present
+    | `implicit_const
+    | `flag
+    | `data1
+    | `ref1
+    | `strx1
+    | `addrx1
+    | `data2
+    | `ref2
+    | `strx2
+    | `addrx2
+    | `strx3
+    | `addrx3
+    | `data4
+    | `ref4
+    | `ref_sup4
+    | `strx4
+    | `addrx4
+    | `data8
+    | `ref8
+    | `ref_sig8
+    | `ref_sup8
+    | `data16
+    | `addr
+    | `strp
+    | `line_strp
+    | `sec_offset
+    | `strp_sup
+    | `ref_addr
+    | `exprloc
+    | `block
+    | `block1
+    | `block2
+    | `block4
+    ) as form ->
+    let size =
+      match form with
+      | `flag_present
+      | `implicit_const
+        -> 0
+      | `flag
+      | `data1
+      | `ref1
+      | `strx1
+      | `addrx1
+        -> 1
+      | `data2
+      | `ref2
+      | `strx2
+      | `addrx2
+        -> 2
+      | `strx3
+      | `addrx3
+        -> 3
+      | `data4
+      | `ref4
+      | `ref_sup4
+      | `strx4
+      | `addrx4
+        -> 4
+      | `data8
+      | `ref8
+      | `ref_sig8
+      | `ref_sup8
+        -> 8
+      | `data16
+        -> 16
+      | `addr
+        -> address_size
+      | `strp
+      | `line_strp
+      | `sec_offset
+      | `strp_sup
+      | `ref_addr
+        -> if is_64bit then 8 else 4
+      | `exprloc
+      | `block
+        -> Read.uleb128 cursor
+      | `block1
+        -> Read.u8 cursor
+      | `block2
+        -> Read.u16 cursor
+      | `block4
+        -> Read.u32 cursor
+    in
+    advance cursor size
+  | `string ->
+    ignore (Read.zero_string cursor () : string option)
+  | `sdata ->
+    ignore (Read.sleb128 cursor : s128)
+  | `udata
+  | `ref_udata
+  | `strx
+  | `addrx
+  | `loclistx
+  | `rnglistx ->
+    ignore (Read.uleb128 cursor : u128)
+  | `indirect ->
+    let t = of_int_exn (Read.uleb128 cursor) in
+    skip t cursor ~is_64bit ~address_size

--- a/src/owee_form.mli
+++ b/src/owee_form.mli
@@ -1,0 +1,54 @@
+(* Form codes are types for DWARF operators. In the spec, they all start with [DW_FORM_]. *)
+type t =
+  [ `addr
+  | `block2
+  | `block4
+  | `data2
+  | `data4
+  | `data8
+  | `string
+  | `block
+  | `block1
+  | `data1
+  | `flag
+  | `sdata
+  | `strp
+  | `udata
+  | `ref_addr
+  | `ref1
+  | `ref2
+  | `ref4
+  | `ref8
+  | `ref_udata
+  | `indirect
+  | `sec_offset
+  | `exprloc
+  | `flag_present
+  | `strx
+  | `addrx
+  | `ref_sup4
+  | `strp_sup
+  | `data16
+  | `line_strp
+  | `ref_sig8
+  | `implicit_const
+  | `loclistx
+  | `rnglistx
+  | `ref_sup8
+  | `strx1
+  | `strx2
+  | `strx3
+  | `strx4
+  | `addrx1
+  | `addrx2
+  | `addrx3
+  | `addrx4
+  ]
+
+(* [read cursor] reads a form code out of an Owee_buf, and advance the buffer past it. *)
+val read : Owee_buf.cursor -> t
+
+val of_int_exn : int -> t
+
+(* Moves the given cursor past data of type [t]. *)
+val skip : t -> Owee_buf.cursor -> is_64bit:bool -> address_size:int -> unit


### PR DESCRIPTION
This doesn't quite fix #14, but it gets a good chunk of the way there.
Our goals with this change were to teach [magic-trace](https://github.com/janestreet/magic-trace) to trace code
compiled with GCC 11, which turns on DWARF 5 by default.

To that end, we implemented just the parts of the spec necessary to provide
magic-trace symbol and file names. We're not sure if anything else in
DWARF 5 works, but at least it seems not to crash on the ELF files we
tested.

Just to point out one example of something still not supported, owee
still doesn't support split debug info (aka .dwo files). We'd like
it to one day, but it sounds harder than what we've done here.

This patch was authored jointly by @billduff and @cgaebel.

Testing: We tested this by running magic-trace on itself and seeing
symbols and filenames from C functions compiled with GCC 11.