### PR TITLE
Fix tests

### DIFF
--- a/examples/decodedline_elf.ml
+++ b/examples/decodedline_elf.ml
@@ -17,7 +17,7 @@ let () =
   | None -> ()
   | Some section ->
     let pointers_to_other_sections =
-      Owee_elf.debug_line_pointers buffer sections
+      Some (Owee_elf.debug_line_pointers buffer sections)
     and body =
       Owee_buf.cursor (Owee_elf.section_body buffer section)
     in

--- a/examples/decodedline_elf.ml
+++ b/examples/decodedline_elf.ml
@@ -2,11 +2,21 @@
    output should be similar to
    objdump --dwarf=decodedline <mybin>
 *)
+let useage () =
+  (prerr_endline ("Usage: " ^ Sys.argv.(0) ^ " my_binary.elf [-no-address]"); exit 1)
+
 let path =
   if Array.length Sys.argv <= 1 then
-    (prerr_endline ("Usage: " ^ Sys.argv.(0) ^ " my_binary.elf"); exit 1)
+    useage ()
   else
     Sys.argv.(1)
+
+let print_address =
+  if Array.length Sys.argv <= 2 then
+    true
+  else match Sys.argv.(2) with
+    | "-no-address" -> false
+    | _ -> useage ()
 
 let buffer = Owee_buf.map_binary path
 
@@ -31,7 +41,11 @@ let () =
           match get_filename header state with
           | None -> ()
           | Some filename ->
-            Printf.printf "%s\t%d\t0x%x\n" filename state.line state.address
+            Printf.printf "%s\t%d" filename state.line;
+            if print_address then
+              Printf.printf "\t0x%x\n" state.address
+            else
+              print_newline ()
         in
         Owee_debug_line.fold_rows (header, chunk) check ();
         aux ()

--- a/examples/decodedline_macho.ml
+++ b/examples/decodedline_macho.ml
@@ -26,7 +26,7 @@ let debug_section segment = function
     as section ->
     let body = Owee_buf.cursor (Owee_macho.section_body buffer segment section) in
     let rec aux () =
-      match Owee_debug_line.read_chunk body with
+      match Owee_debug_line.read_chunk body ~pointers_to_other_sections:None with
       | None -> ()
       | Some (header, chunk) ->
         let check header state () =

--- a/examples/dune
+++ b/examples/dune
@@ -3,7 +3,7 @@
  (libraries owee unix))
 
 (alias
- (name examples)
+ (name runtest)
  (deps decodedline_elf.exe decodedline_macho.exe 
        functions.exe locate.exe
        read_buildid.exe read_stapsdt_probes.exe))
@@ -22,8 +22,8 @@
  (targets test-dwarf-4.output test-dwarf-5.output)
  (action
   (progn
-   (with-stdout-to test-dwarf-4.output (run %{exe:decodedline_elf.exe} test-4.bin))
-   (with-stdout-to test-dwarf-5.output (run %{exe:decodedline_elf.exe} test-5.bin)))))
+   (with-stdout-to test-dwarf-4.output (run %{exe:decodedline_elf.exe} test-4.bin -no-address))
+   (with-stdout-to test-dwarf-5.output (run %{exe:decodedline_elf.exe} test-5.bin -no-address)))))
 
 (rule
  (alias runtest)

--- a/examples/test-dwarf-4.expected
+++ b/examples/test-dwarf-4.expected
@@ -1,3 +1,3 @@
-test.c	2	0x1119
-test.c	3	0x1124
-test.c	4	0x1129
+test.c	2
+test.c	3
+test.c	4

--- a/examples/test-dwarf-5.expected
+++ b/examples/test-dwarf-5.expected
@@ -1,3 +1,3 @@
-test.c	2	0x1119
-test.c	3	0x1124
-test.c	4	0x1129
+test.c	2
+test.c	3
+test.c	4

--- a/src/owee_debug_line.ml
+++ b/src/owee_debug_line.ml
@@ -109,7 +109,7 @@ let skip_directories t ~is_64bit ~version ~address_size =
 let read_filenames_version_lt_5 t =
   let rec loop acc =
     match read_filename_version_lt_5 t with
-    | "" -> acc 
+    | "" -> acc
     | fname ->
       (*Printf.eprintf "%S\n%!" fname;*)
       loop (fname :: acc)
@@ -166,11 +166,15 @@ let read_filenames
     read_filenames_version_lt_5 t
   else begin
     let address_size = unwrap_address_size_v5_only address_size in
-    read_filenames_version_gte_5
-      t
-      ~pointers_to_other_sections 
-      ~is_64bit
-      ~address_size
+        match pointers_to_other_sections with
+    | None ->
+      invalid_format "Owee needs pointers_to_other_sections for Dwarf5"
+    | Some pointers_to_other_sections ->
+      read_filenames_version_gte_5
+        t
+        ~pointers_to_other_sections
+        ~is_64bit
+        ~address_size
   end
 
 let read_prologue_length t ~is_64bit =

--- a/src/owee_debug_line.mli
+++ b/src/owee_debug_line.mli
@@ -19,7 +19,7 @@ type pointers_to_other_sections = {
     {! Owee_elf.debug_line_pointers} to construct such a value. *)
 val read_chunk
   :  cursor
-  -> pointers_to_other_sections:pointers_to_other_sections
+  -> pointers_to_other_sections:pointers_to_other_sections option
   -> (header * cursor) option
 
 (** State of the linenumber automaton.

--- a/src/owee_location.ml
+++ b/src/owee_location.ml
@@ -75,7 +75,8 @@ let extract_debug_info buffer =
   | Some section ->
     (*Printf.eprintf "Looking for 0x%X\n" t;*)
     let body = Owee_elf.section_body buffer section in
-    let pointers_to_other_sections = Owee_elf.debug_line_pointers buffer sections in
+    let pointers_to_other_sections =
+      Some (Owee_elf.debug_line_pointers buffer sections) in
     let count = count_rows body ~pointers_to_other_sections in
     let debug_entries = Array.make count
         {addr_lo = max_int; addr_hi = max_int; payload = None} in


### PR DESCRIPTION
1) Make `pointers_to_other_sections` optional in `Owee_debug_line.read_chunk` to fix build of `deadcodedline_macho` test. Not sure if anyone uses this library on a mac, but we have the test, and the code, and maybe someone will add dwarf 5 support to it later. 

2) Remove addresses from the output of new dwarf tests. It's not as good of a test without them, but better than not having any tests.