### PR TITLE
Fixes a off-by-one error when searching for the closest interval

### DIFF
--- a/src/owee_interval_map.ml
+++ b/src/owee_interval_map.ml
@@ -208,7 +208,7 @@ let closest_key intervals (addr : int) =
   while !l <= !r do
     let m = !l + (!r - !l) / 2 in
     let lb = intervals.(m).lbound in
-    if lb < addr then
+    if lb <= addr then
       l := m + 1
     else
       r := m - 1


### PR DESCRIPTION
It's possible for an ELF file to contain several symbols covering the same range in memory. 

If someone where to query owee to retrieve all symbols for an address `A`, and that there was several symbols with the same size all starting on `A`, then Owee wouldn't be able to return all symbols.
This fixes this bug by making `Owee_interval_map.closest_key intervals addr` return the last key equal to `addr` if they were several of them. 