### PR TITLE
Support relocations in Owee

### DIFF
--- a/examples/relocations.ml
+++ b/examples/relocations.ml
@@ -1,0 +1,70 @@
+[@@@ocaml.warning "+a-4-9-30-40-41-42"]
+
+(* `readelf -rW <binary> | sed "s/@[^ ]\+//"` and
+   `relocations.exe  <binary> | sed "s/@[^ ]\+//"` should
+   return the same thing.
+*)
+
+let path, address =
+  let argv_len = Array.length Sys.argv in
+  if argv_len < 1 || argv_len > 3 then
+    (prerr_endline ("Usage: " ^ Sys.argv.(0)
+      ^ " my_binary.elf [ADDRESS]"); exit 1)
+  else
+    let path = Sys.argv.(1) in
+    let address =
+      if argv_len = 3 then Some (Int64.of_string Sys.argv.(2)) else None
+    in
+    path, address
+
+let buffer =
+  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+  let len = Unix.lseek fd 0 Unix.SEEK_END in
+  let map = Unix.map_file
+      fd Bigarray.int8_unsigned Bigarray.c_layout false [|len|]
+  in
+  Unix.close fd;
+  Bigarray.array1_of_genarray map
+
+let _header, sections = Owee_elf.read_elf buffer
+
+let info_to_string = function
+  | 7 -> "R_X86_64_JUMP_SLOT"
+  | 1 -> "R_X86_64_64"
+  | 6 -> "R_X86_64_GLOB_DAT"
+  | 5 -> "R_X86_64_COPY"
+  | x -> failwith ("Rel type " ^ string_of_int x ^ " unhandled")
+
+let display dynsym strtab relocations name =
+  match relocations with
+  | None -> ()
+  | Some relocations ->
+    Printf.printf "Relocation section '%s' at offset %#Lx contains %d entries:\n"
+      name
+      relocations.Owee_rel.section.sh_offset
+      (Array.length relocations.entries);
+    Printf.printf "  Offset          Info           Type           Symbol's Value    Symbol's Name + Addend\n";
+    Array.iter (fun entry ->
+      let sym = Owee_elf.Symbol_table.get dynsym entry in
+      let name = Option.value (Owee_elf.Symbol_table.Symbol.name sym strtab) ~default:"<unknown>" in
+      Printf.printf "%016Lx  %016Lx %17s %016Lx %s + %Lx\n"
+        (Owee_rel_entry.offset entry)
+        (Owee_rel_entry.info entry)
+        (info_to_string (Owee_rel_entry.type_ entry))
+        (Owee_elf.Symbol_table.Symbol.value sym)
+        name
+        (Option.value ~default:0L (Owee_rel_entry.addend entry))
+    ) relocations.entries;
+    Printf.printf "\n"
+
+let () =
+  match Owee_elf.find_section_body buffer sections ~section_name:".dynsym" with
+  | None -> failwith "Symbol table not found"
+  | Some dynsym ->
+    match Owee_elf.find_dynamic_string_table buffer sections with
+    | None -> failwith "String table not found"
+    | Some strtab ->
+        display dynsym strtab (Owee_rel.read_rel ~type_:`Plt buffer sections) ".rel.plt";
+        display dynsym strtab (Owee_rel.read_rel ~type_:`Dyn buffer sections) ".rel.dyn";
+        display dynsym strtab (Owee_rel.read_rela ~type_:`Plt buffer sections) ".rela.plt";
+        display dynsym strtab (Owee_rel.read_rela ~type_:`Dyn buffer sections) ".rela.dyn"

--- a/src/owee_buf.ml
+++ b/src/owee_buf.ml
@@ -47,6 +47,7 @@ type u16 = int
 type s32 = int
 type u32 = int
 type u64 = int64
+type i64 = int64
 type s128 = int
 type u128 = int
 
@@ -89,6 +90,10 @@ module Read = struct
     done;
     advance t 8;
     !result
+
+  let i64 t : i64 =
+    (* u64 are wrapped in an i64 and are actually signed. *)
+    u64 t
 
   let uleb128 t : u128 =
     let rec aux t shift acc =

--- a/src/owee_buf.mli
+++ b/src/owee_buf.mli
@@ -23,6 +23,7 @@ type u16  = int
 type s32  = int
 type u32  = int
 type u64  = int64
+type i64  = int64
 type s128 = int (* Ahem, we don't expect 128 bits to really consume 128 bits *)
 type u128 = int
 
@@ -50,6 +51,7 @@ module Read : sig
   val u32     : cursor -> u32
   val u32be   : cursor -> u32
   val u64     : cursor -> u64
+  val i64     : cursor -> i64
   val uleb128 : cursor -> u128
   val sleb128 : cursor -> s128
 

--- a/src/owee_elf.mli
+++ b/src/owee_elf.mli
@@ -74,6 +74,7 @@ end
 
 (** Fish out the string table from the given ELF buffer and section array. *)
 val find_string_table : Owee_buf.t -> section array -> String_table.t option
+val find_dynamic_string_table : Owee_buf.t -> section array -> String_table.t option
 
 module Symbol_table : sig
   (** One or more ELF symbol tables, conjoined. *)
@@ -117,6 +118,7 @@ module Symbol_table : sig
     val binding_attribute : t -> binding_attribute
     val visibility : t -> visibility
     val section_header_table_index : t -> int
+    val index : t -> int
   end
 
   (** The symbols in the table whose value and size determine that they
@@ -135,8 +137,15 @@ module Symbol_table : sig
 
   (** [iter t ~f] calls f on each symbol found in [t]. *)
   val iter : t -> f:(Symbol.t -> unit) -> unit
+
+  (** [get buf relocation] returns the symbol associated with [relocation] in [buf].
+      We assume that [buf] is the start of the body of the section specified by
+      the [section.sh_link] field of [Owee_rel.t] for the [relocation].
+  *)
+  val get : Owee_buf.t -> Owee_rel_entry.t -> Symbol.t
 end
 
 (** Fish out both the dynamic and static symbol tables (.dynsym and .symtab)
     from the given ELF buffer and section array. *)
 val find_symbol_table : Owee_buf.t -> section array -> Symbol_table.t option
+val find_dynamic_symbol_table : Owee_buf.t -> section array -> Symbol_table.t option

--- a/src/owee_rel.ml
+++ b/src/owee_rel.ml
@@ -1,0 +1,28 @@
+open Owee_buf
+open Owee_elf
+
+type t = {
+  section : Owee_elf.section;
+  entries : Owee_rel_entry.t array;
+}
+
+let read ~type_ ~section_name ~read buf sections =
+  let section_name = match type_ with
+    | `Plt -> section_name ^ ".plt"
+    | `Dyn -> section_name ^ ".dyn"
+  in
+  let section = Owee_elf.find_section sections section_name in
+  let section_body = Owee_elf.find_section_body buf sections ~section_name in
+  match section, section_body with
+  | Some header, Some body ->
+    let nr_rel_entries = Int64.div (header : section).sh_size  header.sh_entsize in
+    let cur = cursor body in
+    let entries =
+      Array.init (Int64.to_int nr_rel_entries) (fun _ -> read cur)
+    in
+    Some { section = header;
+           entries }
+  | _ -> None
+
+let read_rela = read ~section_name:".rela" ~read:Owee_rel_entry.read_rela
+let read_rel = read ~section_name:".rel" ~read:Owee_rel_entry.read_rel

--- a/src/owee_rel.mli
+++ b/src/owee_rel.mli
@@ -1,0 +1,21 @@
+open! Owee_buf
+
+type t = private {
+  (* Section header of this relocation entry *)
+  section : Owee_elf.section;
+  (* Relocation entries. The ordering is preserved, meaning that the i-th element
+     of this array is the i-th entry from the section. *)
+  entries : Owee_rel_entry.t array;
+}
+
+(** [read_rela ~type_ buf sections] returns the list of relocations stored in the .rela
+    section of the specified type.
+    Returns None if there are no relocations.
+*)
+val read_rela : type_:[`Plt | `Dyn ] -> Owee_buf.t -> Owee_elf.section array -> t option
+
+(** [read_rel ~type_ buf sections] returns the list of relocations stored in the .rel
+    section of the specified type.
+    Returns None if there are no relocations.
+*)
+val read_rel : type_:[`Plt | `Dyn ] -> Owee_buf.t -> Owee_elf.section array -> t option

--- a/src/owee_rel_entry.ml
+++ b/src/owee_rel_entry.ml
@@ -1,0 +1,26 @@
+open! Owee_buf
+
+type t = {
+  r_offset : u64;
+  r_info : u64;
+  r_addend: i64 option;
+}
+
+let read_rela cur =
+  let r_offset = Read.u64 cur in
+  let r_info = Read.u64 cur in
+  let r_addend = Some (Read.i64 cur) in
+  { r_offset; r_info; r_addend }
+
+let read_rel cur =
+  let r_offset = Read.u64 cur in
+  let r_info = Read.u64 cur in
+  (* Addend is to be extracted from the location to be relocated. *)
+  { r_offset; r_info; r_addend = None }
+
+let addend t = t.r_addend
+let offset t = t.r_offset
+let info t = t.r_info
+(* cf https://www.sco.com/developers/gabi/latest/ch4.reloc.html *)
+let type_ t = Int64.logand t.r_info 0xffffffffL |> Int64.to_int
+let symbol_index t = Int64.shift_right_logical t.r_info 32 |> Int64.to_int

--- a/src/owee_rel_entry.mli
+++ b/src/owee_rel_entry.mli
@@ -1,0 +1,12 @@
+open! Owee_buf
+
+type t
+
+val addend : t -> i64 option
+val offset : t -> u64
+val info : t -> u64
+val type_ : t -> u32
+val symbol_index : t -> u32
+
+val read_rela : cursor -> t
+val read_rel : cursor -> t


### PR DESCRIPTION
Support relocation in Owee.

This adds:
- `Owee_elf.find_dynamic_string_table` to retrieve the dynamic string table
- `Owee_elf.find_dynamic_symbol_table` to retrieve the dynamic symbol table
- `Owee_elf.Symbol_table.get` to retrieve the symbol corresponding to a given relocation entry
- `Owee_rel.read_rel` and `Owee_rel.read_rela` to read relocation entries present in the `rel` / `rela` section.

To test it you can run `examples/relocations.ml` and compare the output with the one of `readelf -rW`