### PR TITLE
An optional argument for pointers to other sections

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,11 @@
+Owee 0.7
+========
+Fri May 12 19:02:16 JST 2023
+
+- Test fixes by @gretay-js
+- Bug fix in interval map by @poechsel
+- Added support for relocations by @poechsel
+
 Owee 0.6
 ========
 Mon Apr 18 10:59:40 JST 2022

--- a/examples/decodedline_elf.ml
+++ b/examples/decodedline_elf.ml
@@ -28,7 +28,7 @@ let () =
   | None -> ()
   | Some section ->
     let pointers_to_other_sections =
-      Some (Owee_elf.debug_line_pointers buffer sections)
+      Owee_elf.debug_line_pointers buffer sections
     and body =
       Owee_buf.cursor (Owee_elf.section_body buffer section)
     in

--- a/examples/decodedline_macho.ml
+++ b/examples/decodedline_macho.ml
@@ -26,7 +26,7 @@ let debug_section segment = function
     as section ->
     let body = Owee_buf.cursor (Owee_macho.section_body buffer segment section) in
     let rec aux () =
-      match Owee_debug_line.read_chunk body ~pointers_to_other_sections:None with
+      match Owee_debug_line.read_chunk body ?pointers_to_other_sections:None with
       | None -> ()
       | Some (header, chunk) ->
         let check header state () =

--- a/src/owee_debug_line.ml
+++ b/src/owee_debug_line.ml
@@ -233,7 +233,7 @@ let read_header t ~pointers_to_other_sections =
   in
   (header, chunk)
 
-let read_chunk t ~pointers_to_other_sections =
+let read_chunk ?pointers_to_other_sections t =
   if at_end t
   then None
   else Some (read_header t ~pointers_to_other_sections)

--- a/src/owee_debug_line.mli
+++ b/src/owee_debug_line.mli
@@ -18,8 +18,8 @@ type pointers_to_other_sections = {
     pointers to strings in entirely separate sections of DWARF. You can use
     {! Owee_elf.debug_line_pointers} to construct such a value. *)
 val read_chunk
-  :  cursor
-  -> pointers_to_other_sections:pointers_to_other_sections option
+  : ?pointers_to_other_sections:pointers_to_other_sections
+  -> cursor
   -> (header * cursor) option
 
 (** State of the linenumber automaton.

--- a/src/owee_location.ml
+++ b/src/owee_location.ml
@@ -76,7 +76,7 @@ let extract_debug_info buffer =
     (*Printf.eprintf "Looking for 0x%X\n" t;*)
     let body = Owee_elf.section_body buffer section in
     let pointers_to_other_sections =
-      Some (Owee_elf.debug_line_pointers buffer sections) in
+      Owee_elf.debug_line_pointers buffer sections in
     let count = count_rows body ~pointers_to_other_sections in
     let debug_entries = Array.make count
         {addr_lo = max_int; addr_hi = max_int; payload = None} in


### PR DESCRIPTION
@gretay-js or @poechsel: The current build breaks magic-trace 1.0.1 because of the signature change of `Owee_debug_line.read_chunk` (see https://github.com/ocaml/opam-repository/pull/23782).

I suggest to make `pointers_to_other_sections` an optional argument. I think this will preserve the source compatibility and delivers the intended functionality, but as you are the main users, I want to make sure that this look OK for you.